### PR TITLE
Add support of NODE_ENV and log

### DIFF
--- a/config/logs.js
+++ b/config/logs.js
@@ -1,0 +1,18 @@
+const tarsLogs = require('@tars/logs');
+
+let logger = null;
+
+if (process.env.NODE_ENV == "production") {
+    logger = new tarsLogs('TarsRotate');
+} else {
+    logger = {
+        info: (val) => { console.info(val) },
+        debug: (val) => { console.debug(val) },
+        warn: (val) => { console.warn(val) },
+        error: (val) => { console.error(val) },
+    }
+}
+
+module.exports = logger;
+
+

--- a/config/objNames.js
+++ b/config/objNames.js
@@ -1,7 +1,19 @@
+const objNames = {
+    UserService: `RentHouse.UserService.UserServiceObj`,
+}
+
+const locators = {
+    UserService: "@tcp -h 192.168.0.1 -t 60000 -p 12683"
+}
 // 对于非tars运行环境，需要 @tcp ... 来表明目标模块所在的位置。
 // 对于tars运行环境，则不需要
-const registerLocator = "@tcp -h 192.168.0.1 -t 60000 -p 8080"//"@tcp -h moduleIP -t 60000 -p modulePort"
+const registerLocator = 
+    process.env.NODE_ENV == "development"?"@tcp -h 192.168.0.1 -t 60000 -p 8080":""
 
-module.exports = {
-    UserServiceObjName: `RentHouse.UserService.UserServiceObj`, //${registerLocator}
+if (process.env.NODE_ENV == "development") {
+    for (const key in objNames) {
+        objNames[key] += locators[key];
+    }
 }
+
+module.exports = objNames;

--- a/index.js
+++ b/index.js
@@ -1,26 +1,27 @@
+require("dotenv").config();
 const APIRouters = require('./router');
 const bodyParser = require('koa-bodyparser');
 const Koa = require('koa');
 const sessConfig = require('./config/session');
 const session = require('koa-session');
-// const sessionCheck = require('./middlewares/sessionCheck');
+const logger = require('./config/logs');
 
 // server config
 const hostname = process.env.IP || '127.0.0.1';
 const port = process.env.PORT || 8080;
 const app = new Koa();
-// const ENV = process.env.ENV || "test";
+const ENV = process.env.NODE_ENV || "production";
 
 // middlewares
 app.use(session(sessConfig, app));
 app.use(bodyParser());
-// app.use(sessionCheck.loginBefore);
 app.use(APIRouters.routes());
 
 // init & run
 app.host = hostname;
 app.port = port;
+app.env = ENV;
 app.keys = ['BF68FEB7A66E0E2B8E063A7C234E28D5EACEBC6C', '1C1A2B0D1542E709105825568565F890DA771B07'];
 const server = app.listen(app.port, app.host, () => {
-    // console.log(`API gateway listening on ${server.address().address}:${server.address().port}`);
+    logger.info(`API gateway listening on ${server.address().address}:${server.address().port}`);
 })

--- a/modules/User.js
+++ b/modules/User.js
@@ -1,14 +1,14 @@
 const StatusCode = require('../tars/StatusCodeTars').RentHouse.StatusCode;
 const Methods = require("../tools/methods");
 const statusString = require("../tools/statusString");
-const statusStirng = require("../tools/statusString");
-const User = require('../tars/DataBaseServiceTars').RentHouse.User;
 const { UserServiceProxy }  = require("../proxy");
+const logger = require('../config/logs');
 
 const UsersModule = {
 
     // test:
     test: async (ctx) => {
+        logger.debug(`request /test by method ${ctx.request.method} from ${ctx.request.host}`);
         let status = null, res = null;
         try {
             if (Math.random() > 0.6) throw StatusCode.INTERNAL_ERROR;
@@ -21,9 +21,11 @@ const UsersModule = {
             }
             status = StatusCode.SUCCESS;
         } catch (e) {
+            logger.error(`request ${ctx.request.url}: ${e}`);
             status = e;
             res = null;
         } finally {
+            logger.debug('response set')
             ctx.body = statusString.response(status, res);
         }
     },
@@ -48,15 +50,14 @@ const UsersModule = {
                 if (parseInt(status) !== StatusCode.SUCCESS) {
                     throw status;
                 }
-                // set session;
-                // console.log(res, status);
                 ctx.session.user = res;
             }
         } catch (e) {
+            logger.error(e);
             status = e;
             res = null;
         } finally {
-            ctx.body = statusStirng.response(status, res);
+            ctx.body = statusString.response(status, res);
         }
     },
 
@@ -66,6 +67,7 @@ const UsersModule = {
             ctx.session = null;
             status = StatusCode.SUCCESS;
         } catch (e) {
+            logger.error(e);
             status = e;
             res = null;
         } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tars/rpc": "^2.0.14",
     "@tars/stream": "^2.0.3",
     "@tars/utils": "^2.0.1",
+    "dotenv": "^8.2.0",
     "koa": "^2.13.0",
     "koa-bodyparser": "^3.2.0",
     "koa-router": "^9.1.0",

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -1,8 +1,8 @@
 const Tars = require("@tars/rpc").client;
 const USProxy = require('../tars/UserServiceProxy').RentHouse.UserServiceProxy;
-const { UserServiceObjName } = require("../config/objNames");
+const { UserService } = require("../config/objNames");
 
-const UserServiceProxy = Tars.stringToProxy(USProxy, UserServiceObjName);
+const UserServiceProxy = Tars.stringToProxy(USProxy, UserService);
 
 module.exports = {
     UserServiceProxy


### PR DESCRIPTION
Use `NODE_ENV=development` to automatically set logger and remote service locations.

Default is the **production** environment, which means all logs are set up by the TARS log service, and all Register Service Locators are removed.

Use `NODE_ENV=development npm start` to run API-Interface locally. All logs will show on the Console, and Register Service Locators will be automatically added after each ServiceObj.